### PR TITLE
fix: Fix module import errors preventing agents from starting

### DIFF
--- a/blog2-demo/agents/shared/agent_runner.py
+++ b/blog2-demo/agents/shared/agent_runner.py
@@ -11,8 +11,8 @@ import httpx
 from datetime import datetime
 from pydantic import BaseModel
 
-from llm import LLMConfig
-from models import A2AMessage, MessageType
+from .llm import LLMConfig
+from .models import A2AMessage, MessageType
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/blog2-demo/agents/shared/base_agent.py
+++ b/blog2-demo/agents/shared/base_agent.py
@@ -3,10 +3,10 @@ from abc import ABC, abstractmethod
 from typing import Dict, Any, List, Optional, Tuple
 import logging
 import json
-from mcp.schemas import MCPTool, ToolResult, ToolParameter
-from mcp.tool_registry import MCPToolRegistry
-from llm import LLMClient, LLMConfig
-from models import A2AMessage, MessageType
+from .mcp.schemas import MCPTool, ToolResult, ToolParameter
+from .mcp.tool_registry import MCPToolRegistry
+from .llm import LLMClient, LLMConfig
+from .models import A2AMessage, MessageType
 
 logger = logging.getLogger(__name__)
 

--- a/blog2-demo/agents/shared/migrate_to_standard.py
+++ b/blog2-demo/agents/shared/migrate_to_standard.py
@@ -6,9 +6,9 @@ import sys
 
 # Template for updating agent imports
 AGENT_IMPORT_TEMPLATE = """from typing import List, Dict, Any, Optional
-from unified_base_agent import UnifiedBaseAgent
-from mcp.schemas import MCPTool, ToolParameter, ParameterType
-from llm import LLMConfig
+from .unified_base_agent import UnifiedBaseAgent
+from .mcp.schemas import MCPTool, ToolParameter, ParameterType
+from .llm import LLMConfig
 """
 
 # Template for updating main.py to use StandardAgentRunner

--- a/blog2-demo/agents/shared/standard_agent_runner.py
+++ b/blog2-demo/agents/shared/standard_agent_runner.py
@@ -10,9 +10,9 @@ import uvicorn
 import httpx
 from datetime import datetime
 
-from llm import LLMConfig
-from models import A2AMessage, MessageType
-from standard_schemas import (
+from .llm import LLMConfig
+from .models import A2AMessage, MessageType
+from .standard_schemas import (
     A2AMessageRequest, A2AMessageResponse,
     AgentCardResponse, HealthResponse,
     MCPToolsResponse, MCPExecuteRequest, MCPExecuteResponse,

--- a/blog2-demo/agents/shared/unified_base_agent.py
+++ b/blog2-demo/agents/shared/unified_base_agent.py
@@ -4,10 +4,10 @@ from typing import Dict, Any, List, Optional, Tuple
 import logging
 import json
 from datetime import datetime
-from mcp.schemas import MCPTool, ToolResult, ToolParameter
-from mcp.tool_registry import MCPToolRegistry
-from llm import LLMClient, LLMConfig
-from models import A2AMessage, MessageType
+from .mcp.schemas import MCPTool, ToolResult, ToolParameter
+from .mcp.tool_registry import MCPToolRegistry
+from .llm import LLMClient, LLMConfig
+from .models import A2AMessage, MessageType
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
Fixes critical import errors that prevent all agents from starting with `ModuleNotFoundError: No module named 'llm'`

## Problem
All agents were failing on startup with:
```
ModuleNotFoundError: No module named 'llm'
```

## Solution
Updated all imports in the shared module to use relative imports:
- `from llm import ...` → `from .llm import ...`
- `from models import ...` → `from .models import ...`
- `from mcp.schemas import ...` → `from .mcp.schemas import ...`

## Files Changed
- `agents/shared/standard_agent_runner.py`
- `agents/shared/unified_base_agent.py`
- `agents/shared/base_agent.py`
- `agents/shared/agent_runner.py`
- `agents/shared/migrate_to_standard.py`

## Testing
After this fix, agents should start successfully and register with the A2A Registry.

🤖 Generated with [Claude Code](https://claude.ai/code)