### PR TITLE
fix: Fix all module import and syntax errors in agents

### DIFF
--- a/blog2-demo/agents/shared/agent_runner.py
+++ b/blog2-demo/agents/shared/agent_runner.py
@@ -11,8 +11,8 @@ import httpx
 from datetime import datetime
 from pydantic import BaseModel
 
-from .llm import LLMConfig
-from .models import A2AMessage, MessageType
+from llm import LLMConfig
+from models import A2AMessage, MessageType
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/blog2-demo/agents/shared/base_agent.py
+++ b/blog2-demo/agents/shared/base_agent.py
@@ -3,10 +3,10 @@ from abc import ABC, abstractmethod
 from typing import Dict, Any, List, Optional, Tuple
 import logging
 import json
-from .mcp.schemas import MCPTool, ToolResult, ToolParameter
-from .mcp.tool_registry import MCPToolRegistry
-from .llm import LLMClient, LLMConfig
-from .models import A2AMessage, MessageType
+from mcp.schemas import MCPTool, ToolResult, ToolParameter
+from mcp.tool_registry import MCPToolRegistry
+from llm import LLMClient, LLMConfig
+from models import A2AMessage, MessageType
 
 logger = logging.getLogger(__name__)
 

--- a/blog2-demo/agents/shared/migrate_to_standard.py
+++ b/blog2-demo/agents/shared/migrate_to_standard.py
@@ -6,9 +6,9 @@ import sys
 
 # Template for updating agent imports
 AGENT_IMPORT_TEMPLATE = """from typing import List, Dict, Any, Optional
-from .unified_base_agent import UnifiedBaseAgent
-from .mcp.schemas import MCPTool, ToolParameter, ParameterType
-from .llm import LLMConfig
+from unified_base_agent import UnifiedBaseAgent
+from mcp.schemas import MCPTool, ToolParameter, ParameterType
+from llm import LLMConfig
 """
 
 # Template for updating main.py to use StandardAgentRunner

--- a/blog2-demo/agents/shared/standard_agent_runner.py
+++ b/blog2-demo/agents/shared/standard_agent_runner.py
@@ -10,9 +10,9 @@ import uvicorn
 import httpx
 from datetime import datetime
 
-from .llm import LLMConfig
-from .models import A2AMessage, MessageType
-from .standard_schemas import (
+from llm import LLMConfig
+from models import A2AMessage, MessageType
+from standard_schemas import (
     A2AMessageRequest, A2AMessageResponse,
     AgentCardResponse, HealthResponse,
     MCPToolsResponse, MCPExecuteRequest, MCPExecuteResponse,

--- a/blog2-demo/agents/shared/unified_base_agent.py
+++ b/blog2-demo/agents/shared/unified_base_agent.py
@@ -4,10 +4,10 @@ from typing import Dict, Any, List, Optional, Tuple
 import logging
 import json
 from datetime import datetime
-from .mcp.schemas import MCPTool, ToolResult, ToolParameter
-from .mcp.tool_registry import MCPToolRegistry
-from .llm import LLMClient, LLMConfig
-from .models import A2AMessage, MessageType
+from mcp.schemas import MCPTool, ToolResult, ToolParameter
+from mcp.tool_registry import MCPToolRegistry
+from llm import LLMClient, LLMConfig
+from models import A2AMessage, MessageType
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
This PR combines all fixes needed to resolve import and syntax errors preventing agents from starting.

## Problems Fixed

### 1. Module Import Path Issues
The shared modules are imported via `sys.path.append('/app/shared')` which means they're not treated as a Python package. Relative imports like `from .llm import ...` fail with "attempted relative import with no known parent package".

**Solution**: Use absolute imports in all shared modules.

### 2. Syntax Errors
Multiple agents had malformed `super().__init__()` calls causing `SyntaxError: unmatched ')'`

**Solution**: Fixed syntax and added missing methods.

### 3. Missing Import Configuration
GUI agent was missing `sys.path.append('/app/shared')`

**Solution**: Added the required path configuration.

### 4. Class Name Mismatches
`viz-agent/main.py` was importing `VizAgent` but the class is `VisualizationAgent`

**Solution**: Updated to use correct class name.

## All Changes

### Shared Module Import Fixes (most recent commit)
- `agents/shared/unified_base_agent.py` - Changed relative to absolute imports
- `agents/shared/base_agent.py` - Changed relative to absolute imports
- `agents/shared/agent_runner.py` - Changed relative to absolute imports
- `agents/shared/standard_agent_runner.py` - Changed relative to absolute imports
- `agents/shared/migrate_to_standard.py` - Updated template imports

### Agent-Specific Fixes (previous commits)
- `agents/gui-agent/gui_agent.py` - Added sys.path.append
- `agents/viz-agent/viz_agent.py` - Fixed docstring placement, class inheritance
- `agents/viz-agent/main.py` - Fixed class name import
- `agents/data-agent/data_agent.py` - Fixed syntax errors
- `agents/narrative-agent/narrative_agent.py` - Fixed syntax errors
- `agents/research-agent/research_agent.py` - Fixed syntax errors

## Testing
After these fixes, all agents should start successfully:
```bash
docker compose up
```

You should see all 5 agents (data, viz, research, narrative, gui) register successfully with the A2A Registry.

## Technical Details
The key insight is that when using `sys.path.append('/app/shared')`, the shared directory is added to Python's module search path but is NOT treated as a package. This means:
- ✅ `from llm import LLMConfig` works (absolute import)
- ❌ `from .llm import LLMConfig` fails (relative import requires package context)

🤖 Generated with [Claude Code](https://claude.ai/code)